### PR TITLE
If method name is the same with extension it gives error

### DIFF
--- a/code/DataObjectIconRowClassExtension.php
+++ b/code/DataObjectIconRowClassExtension.php
@@ -27,7 +27,7 @@ class DataObjectIconRowClassExtension extends DataExtension
             return $this->owner->GridFieldIconRowClasses;
         }
         $this->owner->GridFieldIconRowClasses = $this->owner->initGridFieldIconRowClass();
-        $this->owner->extend('GridFieldIconRowClasses', $this->owner->GridFieldIconRowClasses);
+        $this->owner->extend('GridFieldIconRowClassesUpdate', $this->owner->GridFieldIconRowClasses);
     }
 
     public function addGridFieldIconRowClass($icon, $title = null, $class = null)


### PR DESCRIPTION
If extension method is of the same name, it will return an empty object.
